### PR TITLE
fix:app.start的container传入null时报错不明确

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,12 @@
 import isPlainObject from 'is-plain-object';
 
 export function check(value, predicate, error) {
-  if(!predicate(value)) {
-    //log('error', 'uncaught at check', error);
+  try {
+    if (!predicate(value)) {
+      //log('error', 'uncaught at check', error);
+      throw new Error(error);
+    }
+  } catch (e) {
     throw new Error(error);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,8 @@
 import isPlainObject from 'is-plain-object';
 
 export function check(value, predicate, error) {
-  try {
-    if (!predicate(value)) {
-      //log('error', 'uncaught at check', error);
-      throw new Error(error);
-    }
-  } catch (e) {
+  if(!predicate(value)) {
+    //log('error', 'uncaught at check', error);
     throw new Error(error);
   }
 }
@@ -23,7 +19,7 @@ export const is = {
   string    : f => typeof f === 'string',
   func      : f => typeof f === 'function',
   number    : n => typeof n === 'number',
-  element   : n => typeof n === 'object' && n.nodeType && n.nodeName,
+  element   : n => typeof n === 'object' && n !== null && n.nodeType && n.nodeName,
   array     : Array.isArray,
   object    : isPlainObject,
   jsx       : v => v && v.$$typeof && v.$$typeof.toString() === 'Symbol(react.element)',


### PR DESCRIPTION
使用`document.getElementById()`等方法，获取不到DOM元素时会返回null。此时报错行在https://github.com/sorrycc/dva/blob/master/src/utils.js#L22 ，错误内容为`Uncaught TypeError: Cannot read property 'nodeType' of null`。表意不明。

参考源码：https://github.com/sorrycc/dva/blob/master/src/index.js#L57 。可以知道预期报错内容为：`Container must be DOMElement.`。与预期不符。

修复了这个问题之后，我觉得`check`函数传入的`error`参数应该调整成一个函数，这样可以获取到传入的`value`，错误信息能够调整为：`Container must be DOMElement, but got ${typeof value}`