### PR TITLE
add onReducer hook to support reducer enhancer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 copy:
 	cp lib/* ./examples/user-dashboard/node_modules/dva/lib/
 	cp lib/* ./examples/count/node_modules/dva/lib/
+	cp lib/* ./examples/count-undo/node_modules/dva/lib/
 	cp lib/* ./examples/friend-list/node_modules/dva/lib/
 	cp lib/* ./examples/popular-products/node_modules/dva/lib/
 

--- a/examples/count-undo/index.js
+++ b/examples/count-undo/index.js
@@ -6,7 +6,13 @@ import undoable, { ActionCreators } from 'redux-undo';
 
 // 1. Initialize
 const app = dva({
-  onReducer: undoable,
+  onReducer: reducer => {
+    return (state, action) => {
+      const undoOpts = {};
+      const newState = undoable(reducer, undoOpts)(state, action);
+      return { ...newState, routing: newState.present.routing };
+    };
+  },
 });
 
 // 2. Model

--- a/examples/count-undo/index.js
+++ b/examples/count-undo/index.js
@@ -5,21 +5,23 @@ import { createHashHistory } from 'history';
 import undoable, { ActionCreators } from 'redux-undo';
 
 // 1. Initialize
-const app = dva();
+const app = dva({
+  onReducer: undoable,
+});
 
 // 2. Model
 app.model({
   namespace: 'count',
   state: 0,
-  reducers: [{
+  reducers: {
     ['count/add'  ](count) { return count + 1 },
     ['count/minus'](count) { return count - 1 },
-  }, undoable],
+  },
 });
 
 // 3. View
-const App = connect(({ count }) => ({
-  count: count.present,
+const App = connect(state => ({
+  count: state.present.count,
 }))(function(props) {
   return (
     <div>

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ function dva(opts = {}) {
 
     // Create store.
     const extraMiddlewares = get('onAction');
+    const reducerEnhancer = get('onReducer');
     const sagaMiddleware = createSagaMiddleware();
     const enhancer = compose(
       applyMiddleware.apply(null, [ routerMiddleware(_history), sagaMiddleware, ...(extraMiddlewares || []) ]),
@@ -99,7 +100,7 @@ function dva(opts = {}) {
     );
     const initialState = opts.initialState || {};
     const store = app.store = createStore(
-      combineReducers(reducers), initialState, enhancer
+      reducerEnhancer(combineReducers(reducers)), initialState, enhancer
     );
 
     // Handle onStateChange.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,6 +6,7 @@ export const hooks = {
   onAction: [],
   onHmr: [],
   extraReducers: [],
+  onReducer: [],
 };
 
 export function use(plugin) {
@@ -42,6 +43,13 @@ export function get(key) {
       ret = { ...ret, ...reducerObj };
     }
     return ret;
+  } else if (key === 'onReducer') {
+    return function(reducer) {
+      for (const reducerEnhancer of hooks[key]) {
+        reducer = reducerEnhancer(reducer);
+      }
+      return reducer;
+    }
   } else {
     return hooks[key];
   }

--- a/test/app.use-test.js
+++ b/test/app.use-test.js
@@ -9,6 +9,7 @@ describe('app.use', () => {
     hooks.onStateChange = [];
     hooks.onAction = [];
     hooks.onHmr = [];
+    hooks.onReducer = [];
     hooks.extraReducers = [];
   });
 
@@ -57,5 +58,22 @@ describe('app.use', () => {
 
     app.store.dispatch({ type: 'test' });
     expect(count).toEqual(1);
+  });
+
+  it('onReducer', () => {
+    let count = 0;
+
+    const undo = r => state => ({ present: r(state) });
+    const app = dva({
+      onReducer: undo,
+    });
+    app.model({
+      namespace: 'count',
+      state: 0,
+    });
+    app.router(({ history }) => <div />);
+    app.start();
+
+    expect(app.store.getState().present.count).toEqual(0);
   });
 });

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -8,6 +8,7 @@ describe('plugin', () => {
     hooks.onStateChange = [];
     hooks.onAction = [];
     hooks.onHmr = [];
+    hooks.onReducer = [];
     hooks.extraReducers = [];
   });
 
@@ -24,10 +25,12 @@ describe('plugin', () => {
       onStateChange: 2,
       onAction: 1,
       extraReducers: { form: 1 },
+      onReducer: (r) => { return (state, action) => { const res = r(state, action); return res + 1; } },
     });
     use({
       onHmr: (x) => { hmrCount += 2 + x },
       extraReducers: { user: 2 },
+      onReducer: (r) => { return (state, action) => { const res = r(state, action); return res * 2; } },
     });
 
     apply('onHmr')(2);
@@ -39,5 +42,7 @@ describe('plugin', () => {
     expect(get('extraReducers')).toEqual({ form: 1, user: 2});
     expect(get('onAction')).toEqual([1]);
     expect(get('onStateChange')).toEqual([2]);
+
+    expect(get('onReducer')(state => state + 1)(0)).toEqual(4);
   });
 });


### PR DESCRIPTION
通过 `onReducer` 支持全局的 reducerEnhancer，其中一个案例是支持 redux-undo。

比如：

```javascript
import undoable from 'redux-undo';
const app = dva({
  onReducer: undoable,
});
...
```

但是这样写顶层的 `routing` 就没了，所以需要把 `routing` 重新移出来。

```javascript
import undoable from 'redux-undo';
const app = dva({
  onReducer: reducer => {
    return (state, action) => {
      const undoOpts = {};
      const newState = undoable(reducer, undoOpts)(state, action);
      return { ...newState, routing: newState.present.routing };
    };
  },
});
```
