### PR TITLE
添加reducers对于错误的监听，也走onError

### DIFF
--- a/src/createDva.js
+++ b/src/createDva.js
@@ -132,11 +132,24 @@ export default function createDva(createOpts) {
       );
 
       function createReducer(asyncReducers) {
-        return reducerEnhancer(combineReducers({
+        const prevAllReducers = {
           ...reducers,
           ...extraReducers,
           ...asyncReducers,
-        }));
+        };
+        const errorWrapReducers = {};
+
+        Object.keys(prevAllReducers).map((key)=> {
+          errorWrapReducers[key] = (...args)=> {
+            try {
+              return prevAllReducers[key](...args);
+            } catch(e) {
+              onError(e);
+            }
+          }
+        });
+
+        return reducerEnhancer(combineReducers(errorWrapReducers));
       }
 
       // extend store


### PR DESCRIPTION
复写reducers，让其也能走onError，效果如下，如果reducers中报错，原来是：

![wangwang20160825162921](https://cloud.githubusercontent.com/assets/1179603/17961945/022f2ae8-6ae1-11e6-89db-069a014b0188.png)

基本上一脸蒙逼，改了之后是，并且统一通过onError，hooks处理：

![wangwang20160825162925](https://cloud.githubusercontent.com/assets/1179603/17961956/111c48e2-6ae1-11e6-9208-676c354b68fb.png)

