### PR TITLE
feat: remove router match from history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,17 +15,6 @@ export default createDva({
   routerMiddleware: routerMiddleware,
 
   setupHistory(history) {
-    const h = this._history = syncHistoryWithStore(history, this._store);
-    const listen = h.listen;
-    const routes = this._router({ history:h });
-    h.listen = callback => {
-      listen.call(h, location => {
-        match({ location, routes }, (error, _, renderProps) => {
-          if (error) throw new Error(error);
-          // renderProps is undefined if redirect
-          callback(location, renderProps || {});
-        });
-      });
-    };
+    this._history = syncHistoryWithStore(history, this._store);
   },
 });


### PR DESCRIPTION
Close #54 

---

match 是为了从 router 里获取 params，之后 params 改为通过 path-to-regexp 获取，参考：dvajs/dva-hackernews@3314c7c