### PR TITLE
fixed reducerEnhancer

### DIFF
--- a/src/createDva.js
+++ b/src/createDva.js
@@ -132,7 +132,7 @@ export default function createDva(createOpts) {
       );
 
       function createReducer(asyncReducers) {
-        return reducerEnhancer(combineReducers({
+        return combineReducers(reducerEnhancer({
           ...reducers,
           ...extraReducers,
           ...asyncReducers,

--- a/test/reducers-test.js
+++ b/test/reducers-test.js
@@ -90,9 +90,9 @@ describe('reducers', () => {
   });
 
   it('onReducer', () => {
-    const undo = r => state => {
-      const newState = r(state);
-      return { present: newState, routing: newState.routing };
+    const undo = state => {
+      const newState = {...state};
+      return { ...newState, count: ()=>{ return {present: newState.count()} } };
     };
     const app = dva({
       onReducer: undo,
@@ -104,7 +104,7 @@ describe('reducers', () => {
     app.router(({ history }) => <div />);
     app.start();
 
-    expect(app._store.getState().present.count).toEqual(0);
+    expect(app._store.getState().count.present).toEqual(0);
   });
 
 });


### PR DESCRIPTION
之前包裹的方式貌似不对，因为`onReducer`传入的函数包裹的已经是 `combineReducers` 之后的了，并不能直接包裹具体的 `reducer`，所以我在尝试使用`redux-undo` 时候，发现怎么搞都不对，最后发现是顺序的问题，改过后就可以正常使用了，如下

```javascript
import undoable from 'redux-undo';
import { ActionCreators } from 'redux-undo';

// use undo
const undo = state => {
  return {...state, count: undoable(state.count)};
};

app.use({
  onReducer: undo,
});

// 2. Model
app.model({
  namespace: 'count',
  state: 0,
  reducers: {
    add  (count) {
      return count + 1
    },
    minus(count) {
      return count - 1
    }
  },
});

// 3. View
const App = connect(({ count }) => ({
  count
}))(function (props) {
  return (
    <div>
      <h2>{ props.count.present }</h2>
      <button key="add" onClick={() => { props.dispatch({type: 'count/add'})}}>+</button>
      <button key="minus" onClick={() => { props.dispatch({type: 'count/minus'})}}>-</button>
      <button key="undo" onClick={() => { props.dispatch(ActionCreators.undo()) } }>undo</button>
    </div>
  );
});
....
```