### PR TITLE
fix user-dashboard edit age  bug

### DIFF
--- a/examples/user-dashboard/src/components/Users/UserModal.jsx
+++ b/examples/user-dashboard/src/components/Users/UserModal.jsx
@@ -33,6 +33,9 @@ const UserModal = ({
   }
 
   function checkNumber(rule, value, callback) {
+    if (!value) {
+      callback(new Error('年龄未填写'));
+    }
     if (!/^[\d]{1,2}$/.test(value)) {
       callback(new Error('年龄不合法'));
     } else {
@@ -72,7 +75,6 @@ const UserModal = ({
           {getFieldDecorator('age', {
             initialValue: item.age,
             rules: [
-              { required: true, message: '年龄未填写' },
               { validator: checkNumber },
             ],
           })(


### PR DESCRIPTION
修复 user-dashboard 从第二页开始，点击编辑用户，什么信息都不修改，点击确定会提示“年龄未填写”。Close #196