### PR TITLE
Fix HistoryModule declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ import {
   MiddlewareAPI,
   StoreEnhancer
 } from 'redux';
+import * as HistoryModule from 'history';
 
 export interface onActionFunc {
   (api: MiddlewareAPI<any>): void;


### PR DESCRIPTION
Add missing HistoryModule.

```
ERROR in /Users/meck/Workspace/dva-boilerplate-typescript/node_modules/dva/index.d.ts
(54,12): error TS2503: Cannot find namespace 'HistoryModule'.

ERROR in /Users/meck/Workspace/dva-boilerplate-typescript/node_modules/dva/index.d.ts
(71,12): error TS2503: Cannot find namespace 'HistoryModule'.
```