### PR TITLE
Remove React import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ import {
 
 
 import {History} from "history";
-import React from "react";
 
 export interface onActionFunc {
   (api: MiddlewareAPI<any>): void;


### PR DESCRIPTION
Since JSX is declared as a global namespace[1], don't need import React explicitly.

1. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f4f0bef0e10b719484c1327166f96fd5bd758db7/react/index.d.ts#L2629-L2630

\cc @pvtyuan 