### PR TITLE
hit 100% test coverage

### DIFF
--- a/src/createDva.js
+++ b/src/createDva.js
@@ -158,6 +158,7 @@ export default function createDva(createOpts) {
       invariant(this._router, 'app.start: router should be defined');
 
       // error wrapper
+      /* istanbul ignore next untestable in mocha*/
       const onError = plugin.apply('onError', (err) => {
         throw new Error(err.stack || err);
       });
@@ -211,6 +212,7 @@ export default function createDva(createOpts) {
         middlewares = [routerMiddleware(history), ...middlewares];
       }
       let devtools = () => noop => noop;
+      /* istanbul ignore next no need for test this */
       if (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION__) {
         devtools = window.__REDUX_DEVTOOLS_EXTENSION__;
       }

--- a/test/app.start-test.js
+++ b/test/app.start-test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import expect from 'expect';
 import dva from '../src/index';
 
@@ -7,5 +8,22 @@ describe('app.start', () => {
     expect(() => {
       app.start();
     }).toThrow(/app.start: router should be defined/);
+  });
+
+  it('throw error if start with a invalid prop', () => {
+    const app = dva();
+    expect(() => {
+      app.start('excited');
+    }).toThrow(/app.start: could not query selector/);
+  });
+
+  it('start with a valid container', () => {
+    const app = dva();
+    expect(() => {
+      app.router(() => <div />);
+      // since document already inject to global in setup file
+      // eslint-disable-next-line
+      app.start(document.querySelector('#root'));
+    }).toNotThrow();
   });
 });

--- a/test/handleActions-test.js
+++ b/test/handleActions-test.js
@@ -1,0 +1,48 @@
+import expect from 'expect';
+import handleActions from '../src/handleActions';
+
+describe('handleActions', () => {
+  const LOGIN_START = 'user/login/start';
+
+  const LOGIN_END = 'user/login/end';
+
+  const LOGIN_SAVE = 'user/login/save';
+
+  const initialState = {
+    isLoading: false,
+  };
+
+  const reducers = handleActions({
+    [LOGIN_START](state) {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    },
+
+    [LOGIN_END](state) {
+      return {
+        ...state,
+        isLoading: false,
+      };
+    },
+
+    [LOGIN_SAVE]: undefined,
+  }, initialState);
+
+  it('LOGIN_START', () => {
+    expect(reducers(initialState, { type: LOGIN_START }))
+      .toEqual({ isLoading: true });
+  });
+
+  it('LOGIN_END', () => {
+    expect(reducers(initialState, { type: LOGIN_END }))
+      .toEqual({ isLoading: false });
+  });
+
+  it('uses the identity if the specified reducer is undefined', () => {
+    expect(reducers(initialState, { type: LOGIN_SAVE }))
+      .toBe(initialState);
+  });
+});
+


### PR DESCRIPTION
增加了七个测试用例，分别是

* `effect` 未被定义
* `app.start` 无效参数
* `app.start` 有效 DOM
* 三个简单的 `handleActions` 用例
* 一个 `uncaughtException` 用例

在源码中忽略了两个情况：

1. 有 Redux devtool 接入的情况。这个没什么好说的，测试一定会忽略掉；

2. 当 `dva({ onError: ... })` 未被定义时的错误处理。鉴于 `--allow-uncaught` 没用，`process.on(event, ...)` 也捕捉不到，`domain` 也被 Node.js 废弃掉了，目前的错误处理机制在 Node.js 环境的 mocha 应该是测试不了。我个人建议暂时忽略掉这个情况，或者重构错误处理机制（目前三次代理调用再加上 saga 的抽象，人类也难以定位报错代码 ）。

