### PR TITLE
add `combineReducers` to use immutable.js

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -155,6 +155,10 @@ e.g. [dva-loading](https://github.com/dvajs/dva-loading) has implement auto load
 
 HMR(Hot Module Replacement) related, currently used in [babel-plugin-dva-hmr](https://github.com/dvajs/babel-plugin-dva-hmr).
 
+#### `combineReducers`
+
+Specify other `combineReducers`， e.g. [redux-immutable](https://github.com/gajus/redux-immutable).
+
 #### `extraReducers`
 
 Specify extra reducers.

--- a/docs/API_zh-CN.md
+++ b/docs/API_zh-CN.md
@@ -60,6 +60,7 @@ const app = dva({
   onReducer,
   onEffect,
   onHmr,
+  combineReducers,
   extraReducers,
   extraEnhancers,
 });
@@ -150,6 +151,10 @@ const app = dva({
 #### `onHmr(fn)`
 
 热替换相关，目前用于 [babel-plugin-dva-hmr](https://github.com/dvajs/babel-plugin-dva-hmr) 。
+
+#### `combineReducers`
+
+指定第三方的 `combineReducers`， 比如 [redux-immutable](https://github.com/gajus/redux-immutable) 。
 
 #### `extraReducers`
 

--- a/package.json
+++ b/package.json
@@ -89,11 +89,13 @@
     "eslint-plugin-react": "^7.0.1",
     "expect": "^1.20.2",
     "husky": "^0.13.4",
+    "immutable": "^3.8.1",
     "jsdom": "^9.5.0",
     "mocha": "^3.4.2",
     "nyc": "^11.0.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "redux-immutable": "^4.0.0",
     "rimraf": "^2.6.1",
     "uglifyjs": "^2.4.11"
   },

--- a/src/createDva.js
+++ b/src/createDva.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
+import { createStore, applyMiddleware, compose, combineReducers as defaultCombineReducers } from 'redux';
 import createSagaMiddleware from 'redux-saga/lib/internal/middleware';
 import * as sagaEffects from 'redux-saga/effects';
 import isPlainObject from 'is-plain-object';
@@ -33,9 +33,11 @@ export default function createDva(createOpts) {
    * Create a dva instance.
    */
   return function dva(hooks = {}) {
-    // history and initialState does not pass to plugin
+    // combineReducers, history and initialState does not pass to plugin
+    const combineReducers = hooks.combineReducers || defaultCombineReducers;
     const history = hooks.history || defaultHistory;
     const initialState = hooks.initialState || {};
+    delete hooks.combineReducers;
     delete hooks.history;
     delete hooks.initialState;
 


### PR DESCRIPTION
原先不支持不全局使用 `immutable` ，在每个 `model` 的 `state` 作为 `immutable` 对象是可行的
但是支持使用 `redux-immutable` 的 `combineReducers` 方法，全局 `state` 使用会更强迫症一点😀

具体实现代码在 `test`  中