### PR TITLE
fix: redux devtools maybe effect other enhancers.

### DIFF
--- a/packages/dva-core/src/createStore.js
+++ b/packages/dva-core/src/createStore.js
@@ -35,8 +35,8 @@ export default function ({
 
   const enhancers = [
     applyMiddleware(...middlewares),
-    devtools(window.__REDUX_DEVTOOLS_EXTENSION__OPTIONS),
     ...extraEnhancers,
+    devtools(window.__REDUX_DEVTOOLS_EXTENSION__OPTIONS),
   ];
 
   return createStore(reducers, initialState, compose(...enhancers));


### PR DESCRIPTION
https://github.com/zalmoxisus/redux-devtools-extension

```jsx
  import { createStore, applyMiddleware, compose } from 'redux';

+ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+ const store = createStore(reducer, /* preloadedState, */ composeEnhancers(
- const store = createStore(reducer, /* preloadedState, */ compose(
    applyMiddleware(...middleware)
  ));
```