### PR TITLE
upgrade react-router-redux

### DIFF
--- a/packages/dva/package.json
+++ b/packages/dva/package.json
@@ -41,7 +41,7 @@
     "react-async-component": "^1.0.0-beta.3",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",
-    "react-router-redux": "5.0.0-alpha.6",
+    "react-router-redux": "5.0.0-alpha.8",
     "redux": "^3.7.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
```
npm WARN react-router-redux@5.0.0-alpha.6 requires a peer of react@^15 but none was installed.
```

https://github.com/ant-design/ant-design-pro/issues/137#issuecomment-342715104