### PR TITLE
修复并发dispatch相同type的effect，只有一个返回promise被resolved的问题

### DIFF
--- a/packages/dva-core/src/createPromiseMiddleware.js
+++ b/packages/dva-core/src/createPromiseMiddleware.js
@@ -1,16 +1,11 @@
-import { NAMESPACE_SEP } from './constants';
+import { NAMESPACE_SEP } from "./constants";
 
 export default function createPromiseMiddleware(app) {
-  const map = {};
-
-  const middleware = () => next => (action) => {
+  return () => next => action => {
     const { type } = action;
     if (isEffect(type)) {
       return new Promise((resolve, reject) => {
-        map[type] = {
-          resolve: wrapped.bind(null, type, resolve),
-          reject: wrapped.bind(null, type, reject),
-        };
+        next({ resolve, reject, ...action });
       });
     } else {
       return next(action);
@@ -28,27 +23,4 @@ export default function createPromiseMiddleware(app) {
 
     return false;
   }
-
-  function wrapped(type, fn, args) {
-    if (map[type]) delete map[type];
-    fn(args);
-  }
-
-  function resolve(type, args) {
-    if (map[type]) {
-      map[type].resolve(args);
-    }
-  }
-
-  function reject(type, args) {
-    if (map[type]) {
-      map[type].reject(args);
-    }
-  }
-
-  return {
-    middleware,
-    resolve,
-    reject,
-  };
 }

--- a/packages/dva-core/src/createStore.js
+++ b/packages/dva-core/src/createStore.js
@@ -23,8 +23,8 @@ export default function ({
 
   const extraMiddlewares = plugin.get('onAction');
   const middlewares = setupMiddlewares([
-    sagaMiddleware,
     promiseMiddleware,
+    sagaMiddleware,
     ...flatten(extraMiddlewares),
   ]);
 

--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -1,21 +1,21 @@
-import invariant from 'invariant';
-import * as sagaEffects from 'redux-saga/effects';
-import warning from 'warning';
+import invariant from "invariant";
+import * as sagaEffects from "redux-saga/effects";
+import warning from "warning";
 import {
   takeEveryHelper as takeEvery,
   takeLatestHelper as takeLatest,
-  throttleHelper as throttle,
-} from 'redux-saga/lib/internal/sagaHelpers';
-import { NAMESPACE_SEP } from './constants';
-import prefixType from './prefixType';
+  throttleHelper as throttle
+} from "redux-saga/lib/internal/sagaHelpers";
+import { NAMESPACE_SEP } from "./constants";
+import prefixType from "./prefixType";
 
-export default function getSaga(resolve, reject, effects, model, onError, onEffect) {
-  return function *() {
+export default function getSaga(effects, model, onError, onEffect) {
+  return function*() {
     for (const key in effects) {
       if (Object.prototype.hasOwnProperty.call(effects, key)) {
-        const watcher = getWatcher(resolve, reject, key, effects[key], model, onError, onEffect);
+        const watcher = getWatcher(key, effects[key], model, onError, onEffect);
         const task = yield sagaEffects.fork(watcher);
-        yield sagaEffects.fork(function *() {
+        yield sagaEffects.fork(function*() {
           yield sagaEffects.take(`${model.namespace}/@@CANCEL_EFFECTS`);
           yield sagaEffects.cancel(task);
         });
@@ -24,9 +24,9 @@ export default function getSaga(resolve, reject, effects, model, onError, onEffe
   };
 }
 
-function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
+function getWatcher(key, _effect, model, onError, onEffect) {
   let effect = _effect;
-  let type = 'takeEvery';
+  let type = "takeEvery";
   let ms;
 
   if (Array.isArray(_effect)) {
@@ -34,30 +34,28 @@ function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
     const opts = _effect[1];
     if (opts && opts.type) {
       type = opts.type;
-      if (type === 'throttle') {
-        invariant(
-          opts.ms,
-          'app.start: opts.ms should be defined if type is throttle',
-        );
+      if (type === "throttle") {
+        invariant(opts.ms, "app.start: opts.ms should be defined if type is throttle");
         ms = opts.ms;
       }
     }
     invariant(
-      ['watcher', 'takeEvery', 'takeLatest', 'throttle'].indexOf(type) > -1,
-      'app.start: effect type should be takeEvery, takeLatest, throttle or watcher',
+      ["watcher", "takeEvery", "takeLatest", "throttle"].indexOf(type) > -1,
+      "app.start: effect type should be takeEvery, takeLatest, throttle or watcher"
     );
   }
 
-  function *sagaWithCatch(...args) {
+  function* sagaWithCatch(...args) {
+    const { resolve, reject } = args.length > 0 ? args[0] : {};
     try {
       yield sagaEffects.put({ type: `${key}${NAMESPACE_SEP}@@start` });
       const ret = yield effect(...args.concat(createEffects(model)));
       yield sagaEffects.put({ type: `${key}${NAMESPACE_SEP}@@end` });
-      resolve(key, ret);
+      resolve && resolve(ret);
     } catch (e) {
       onError(e);
       if (!e._dontReject) {
-        reject(key, e);
+        reject && reject(e);
       }
     }
   }
@@ -65,13 +63,13 @@ function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
   const sagaWithOnEffect = applyOnEffect(onEffect, sagaWithCatch, model, key);
 
   switch (type) {
-    case 'watcher':
+    case "watcher":
       return sagaWithCatch;
-    case 'takeLatest':
+    case "takeLatest":
       return function*() {
         yield takeLatest(key, sagaWithOnEffect);
       };
-    case 'throttle':
+    case "throttle":
       return function*() {
         yield throttle(ms, key, sagaWithOnEffect);
       };
@@ -84,20 +82,20 @@ function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
 
 function createEffects(model) {
   function assertAction(type, name) {
-    invariant(type, 'dispatch: action should be a plain Object with type');
+    invariant(type, "dispatch: action should be a plain Object with type");
     warning(
       type.indexOf(`${model.namespace}${NAMESPACE_SEP}`) !== 0,
-      `[${name}] ${type} should not be prefixed with namespace ${model.namespace}`,
+      `[${name}] ${type} should not be prefixed with namespace ${model.namespace}`
     );
   }
   function put(action) {
     const { type } = action;
-    assertAction(type, 'sagaEffects.put');
+    assertAction(type, "sagaEffects.put");
     return sagaEffects.put({ ...action, type: prefixType(type, model) });
   }
   function take(type) {
-    if (typeof type === 'string') {
-      assertAction(type, 'sagaEffects.take');
+    if (typeof type === "string") {
+      assertAction(type, "sagaEffects.take");
       return sagaEffects.take(prefixType(type, model));
     } else {
       return sagaEffects.take(type);

--- a/packages/dva-core/src/index.js
+++ b/packages/dva-core/src/index.js
@@ -136,12 +136,8 @@ export function create(hooksAndOpts = {}, createOpts = {}) {
     };
 
     const sagaMiddleware = createSagaMiddleware();
-    const {
-      middleware: promiseMiddleware,
-      resolve,
-      reject,
-    } = createPromiseMiddleware(app);
-    app._getSaga = getSaga.bind(null, resolve, reject);
+    const promiseMiddleware = createPromiseMiddleware(app);
+    app._getSaga = getSaga.bind(null);
 
     const sagas = [];
     const reducers = { ...initialReducer };

--- a/packages/dva-core/test/effects-test.js
+++ b/packages/dva-core/test/effects-test.js
@@ -1,26 +1,28 @@
-import expect from 'expect';
-import { create } from '../src/index';
+import expect from "expect";
+import { create } from "../src/index";
 
 const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
 
-describe('effects', () => {
-  it('put action', (done) => {
+describe("effects", () => {
+  it("put action", done => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
         *addDelay({ payload }, { put, call }) {
           yield call(delay, 100);
-          yield put({ type: 'add', payload });
-        },
-      },
+          yield put({ type: "add", payload });
+        }
+      }
     });
     app.start();
-    app._store.dispatch({ type: 'count/addDelay', payload: 2 });
+    app._store.dispatch({ type: "count/addDelay", payload: 2 });
     expect(app._store.getState().count).toEqual(0);
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(2);
@@ -28,23 +30,25 @@ describe('effects', () => {
     }, 200);
   });
 
-  it('put action with namespace will get a warning', (done) => {
+  it("put action with namespace will get a warning", done => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
         *addDelay({ payload }, { put, call }) {
           yield call(delay, 100);
-          yield put({ type: 'add', payload });
-        },
-      },
+          yield put({ type: "add", payload });
+        }
+      }
     });
     app.start();
-    app._store.dispatch({ type: 'count/addDelay', payload: 2 });
+    app._store.dispatch({ type: "count/addDelay", payload: 2 });
     expect(app._store.getState().count).toEqual(0);
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(2);
@@ -52,111 +56,122 @@ describe('effects', () => {
     }, 200);
   });
 
-  it('take', (done) => {
+  it("take", done => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
         *addDelay({ payload }, { put, call }) {
           yield call(delay, payload.delay || 100);
-          yield put({ type: 'add', payload: payload.amount });
+          yield put({ type: "add", payload: payload.amount });
         },
         *test(action, { put, select, take }) {
-          yield put({ type: 'addDelay', payload: { amount: 2 } });
-          yield take('addDelay/@@end');
+          yield put({ type: "addDelay", payload: { amount: 2 } });
+          yield take("addDelay/@@end");
           const count = yield select(state => state.count);
-          yield put({ type: 'addDelay', payload: { amount: count, delay: 0 } });
-        },
-      },
+          yield put({ type: "addDelay", payload: { amount: count, delay: 0 } });
+        }
+      }
     });
     app.start();
-    app._store.dispatch({ type: 'count/test' });
+    app._store.dispatch({ type: "count/test" });
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(4);
       done();
     }, 300);
   });
 
-  it('dispatch action for other models', () => {
+  it("dispatch action for other models", () => {
     const app = create();
     app.model({
-      namespace: 'loading',
+      namespace: "loading",
       state: false,
       reducers: {
-        show() { return true; },
-      },
+        show() {
+          return true;
+        }
+      }
     });
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       effects: {
         *addDelay(_, { put }) {
-          yield put({ type: 'loading/show' });
-        },
-      },
+          yield put({ type: "loading/show" });
+        }
+      }
     });
     app.start();
-    app._store.dispatch({ type: 'count/addDelay' });
+    app._store.dispatch({ type: "count/addDelay" });
     expect(app._store.getState().loading).toEqual(true);
   });
 
-  it('onError', () => {
+  it("onError", () => {
     const errors = [];
     const app = create({
       onError: (error, dispatch) => {
         errors.push(error.message);
-        dispatch({ type: 'count/add' });
-      },
+        dispatch({ type: "count/add" });
+      }
     });
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
         *addDelay({ payload }, { put }) {
           if (!payload) {
-            throw new Error('effect error');
+            throw new Error("effect error");
           } else {
-            yield put({ type: 'add', payload });
+            yield put({ type: "add", payload });
           }
-        },
-      },
+        }
+      }
     });
     app.start();
-    app._store.dispatch({ type: 'count/addDelay' });
-    expect(errors).toEqual(['effect error']);
+    app._store.dispatch({ type: "count/addDelay" });
+    expect(errors).toEqual(["effect error"]);
     expect(app._store.getState().count).toEqual(1);
-    app._store.dispatch({ type: 'count/addDelay', payload: 2 });
+    app._store.dispatch({ type: "count/addDelay", payload: 2 });
     expect(app._store.getState().count).toEqual(3);
   });
 
-  it('type: takeLatest', (done) => {
+  it("type: takeLatest", done => {
     const app = create();
-    const takeLatest = { type: 'takeLatest' };
+    const takeLatest = { type: "takeLatest" };
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
-        addDelay: [function*({ payload }, { call, put }) {
-          yield call(delay, 100);
-          yield put({ type: 'add', payload });
-        }, takeLatest],
-      },
+        addDelay: [
+          function*({ payload }, { call, put }) {
+            yield call(delay, 100);
+            yield put({ type: "add", payload });
+          },
+          takeLatest
+        ]
+      }
     });
     app.start();
 
     // Only catch the last one.
-    app._store.dispatch({ type: 'count/addDelay', payload: 2 });
-    app._store.dispatch({ type: 'count/addDelay', payload: 3 });
+    app._store.dispatch({ type: "count/addDelay", payload: 2 });
+    app._store.dispatch({ type: "count/addDelay", payload: 3 });
 
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(3);
@@ -164,40 +179,50 @@ describe('effects', () => {
     }, 200);
   });
 
-  xit('type: throttle throw error if no ms', () => {
+  xit("type: throttle throw error if no ms", () => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       effects: {
-        addDelay: [function*() { console.log(1); }, { type: 'throttle' }],
-      },
+        addDelay: [
+          function*() {
+            console.log(1);
+          },
+          { type: "throttle" }
+        ]
+      }
     });
     expect(() => {
       app.start();
     }).toThrow(/app.start: opts.ms should be defined if type is throttle/);
   });
 
-  it('type: throttle', (done) => {
+  it("type: throttle", done => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
-        addDelay: [function*({ payload }, { call, put }) {
-          yield call(delay, 100);
-          yield put({ type: 'add', payload });
-        }, { type: 'throttle', ms: 100 }],
-      },
+        addDelay: [
+          function*({ payload }, { call, put }) {
+            yield call(delay, 100);
+            yield put({ type: "add", payload });
+          },
+          { type: "throttle", ms: 100 }
+        ]
+      }
     });
     app.start();
 
     // Only catch the last one.
-    app._store.dispatch({ type: 'count/addDelay', payload: 2 });
-    app._store.dispatch({ type: 'count/addDelay', payload: 3 });
+    app._store.dispatch({ type: "count/addDelay", payload: 2 });
+    app._store.dispatch({ type: "count/addDelay", payload: 3 });
 
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(2);
@@ -205,30 +230,35 @@ describe('effects', () => {
     }, 200);
   });
 
-  it('type: watcher', (done) => {
-    const watcher = { type: 'watcher' };
+  it("type: watcher", done => {
+    const watcher = { type: "watcher" };
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
-        addWatcher: [function*({ take, put, call }) {
-          while (true) {
-            const { payload } = yield take('addWatcher');
-            yield call(delay, 100);
-            yield put({ type: 'add', payload });
-          }
-        }, watcher],
-      },
+        addWatcher: [
+          function*({ take, put, call }) {
+            while (true) {
+              const { payload } = yield take("addWatcher");
+              yield call(delay, 100);
+              yield put({ type: "add", payload });
+            }
+          },
+          watcher
+        ]
+      }
     });
     app.start();
 
     // Only catch the first one.
-    app._store.dispatch({ type: 'count/addWatcher', payload: 2 });
-    app._store.dispatch({ type: 'count/addWatcher', payload: 3 });
+    app._store.dispatch({ type: "count/addWatcher", payload: 2 });
+    app._store.dispatch({ type: "count/addWatcher", payload: 3 });
 
     setTimeout(() => {
       expect(app._store.getState().count).toEqual(2);
@@ -236,14 +266,19 @@ describe('effects', () => {
     }, 200);
   });
 
-  xit('nonvalid type', () => {
+  xit("nonvalid type", () => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       effects: {
-        addDelay: [function*() { console.log(1); }, { type: 'nonvalid' }],
-      },
+        addDelay: [
+          function*() {
+            console.log(1);
+          },
+          { type: "nonvalid" }
+        ]
+      }
     });
 
     expect(() => {
@@ -251,9 +286,9 @@ describe('effects', () => {
     }).toThrow(/app.start: effect type should be takeEvery, takeLatest, throttle or watcher/);
   });
 
-  it('onEffect', (done) => {
-    const SHOW = '@@LOADING/SHOW';
-    const HIDE = '@@LOADING/HIDE';
+  it("onEffect", done => {
+    const SHOW = "@@LOADING/SHOW";
+    const HIDE = "@@LOADING/HIDE";
 
     const app = create();
 
@@ -274,7 +309,7 @@ describe('effects', () => {
             default:
               return state;
           }
-        },
+        }
       },
       onEffect(effect, { put }, model, key) {
         expectedKey = key;
@@ -285,7 +320,7 @@ describe('effects', () => {
           yield effect(...args);
           yield put({ type: HIDE });
         };
-      },
+      }
     });
 
     app.use({
@@ -295,31 +330,33 @@ describe('effects', () => {
           yield effect(...args);
           count += 1;
         };
-      },
+      }
     });
 
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state) { return state + 1; },
+        add(state) {
+          return state + 1;
+        }
       },
       effects: {
         *addRemote(action, { put }) {
           yield delay(100);
-          yield put({ type: 'add' });
-        },
-      },
+          yield put({ type: "add" });
+        }
+      }
     });
 
     app.start();
 
     expect(app._store.getState().loading).toEqual(false);
 
-    app._store.dispatch({ type: 'count/addRemote' });
+    app._store.dispatch({ type: "count/addRemote" });
     expect(app._store.getState().loading).toEqual(true);
-    expect(modelNamespace).toEqual('count');
-    expect(expectedKey).toEqual('count/addRemote');
+    expect(modelNamespace).toEqual("count");
+    expect(expectedKey).toEqual("count/addRemote");
 
     setTimeout(() => {
       expect(app._store.getState().loading).toEqual(false);
@@ -329,39 +366,84 @@ describe('effects', () => {
     }, 200);
   });
 
-  it('return Promise', (done) => {
+  it("return Promise", done => {
     const app = create();
     app.model({
-      namespace: 'count',
+      namespace: "count",
       state: 0,
       reducers: {
-        add(state, { payload }) { return state + payload || 1; },
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
       },
       effects: {
         *addDelay({ payload }, { put, call, select }) {
           yield call(delay, payload.delay || 100);
-          yield put({ type: 'add', payload: payload.amount });
+          yield put({ type: "add", payload: payload.amount });
           return yield select(state => state.count);
-        },
-      },
+        }
+      }
     });
     app.start();
     const p1 = app._store.dispatch({
-      type: 'count/addDelay',
-      payload: { amount: 2 },
+      type: "count/addDelay",
+      payload: { amount: 2 }
     });
     const p2 = app._store.dispatch({
-      type: 'count/add',
-      payload: 2,
+      type: "count/add",
+      payload: 2
     });
     expect(p1 instanceof Promise).toEqual(true);
-    expect(p2).toEqual({ type: 'count/add', payload: 2 });
+    expect(p2).toEqual({ type: "count/add", payload: 2 });
     expect(app._store.getState().count).toEqual(2);
-    p1.then((count) => {
+    p1.then(count => {
       expect(count).toEqual(4);
       expect(app._store.getState().count).toEqual(4);
       done();
     });
   });
+  it("handling the same effects' concurrent return promises", done => {
+    const app = create();
+    app.model({
+      namespace: "count",
+      state: 0,
+      reducers: {
+        add(state, { payload }) {
+          return state + payload || 1;
+        }
+      },
+      effects: {
+        *addDelay({ payload }, { put, call, select }) {
+          yield call(delay, payload.delay || 100);
+          yield put({ type: "add", payload: payload.amount });
+          return yield select(state => state.count);
+        }
+      }
+    });
+    app.start();
+    const p1 = app._store.dispatch({
+      type: "count/addDelay",
+      payload: { delay: 100, amount: 1 }
+    });
+    const p2 = app._store.dispatch({
+      type: "count/add",
+      payload: 2
+    });
+    const p3 = app._store.dispatch({
+      type: "count/addDelay",
+      payload: { delay: 200, amount: 3 }
+    });
+    expect(p1 instanceof Promise).toEqual(true);
+    expect(p2).toEqual({ type: "count/add", payload: 2 });
+    expect(app._store.getState().count).toEqual(2);
+    p1.then(count => {
+      expect(count).toEqual(3);
+      expect(app._store.getState().count).toEqual(3);
+      p3.then(count => {
+        expect(count).toEqual(6);
+        expect(app._store.getState().count).toEqual(6);
+        done();
+      });
+    });
+  });
 });
-


### PR DESCRIPTION
在createPromiseMiddleware中，effect返回结果promise的{resolve, reject}是和type关联在一个map中的，当并发dispatch相同type的effect时，后执行的会覆盖先执行的，所以最终只会有一个被resolved，导致其它的promises一直是pending状态。