### PR TITLE
fix action type is '' in hadleActions.js

### DIFF
--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -9,11 +9,11 @@ import {
 import { NAMESPACE_SEP } from './constants';
 import prefixType from './prefixType';
 
-export default function getSaga(resolve, reject, effects, model, onError, onEffect) {
+export default function getSaga(effects, model, onError, onEffect) {
   return function *() {
     for (const key in effects) {
       if (Object.prototype.hasOwnProperty.call(effects, key)) {
-        const watcher = getWatcher(resolve, reject, key, effects[key], model, onError, onEffect);
+        const watcher = getWatcher(key, effects[key], model, onError, onEffect);
         const task = yield sagaEffects.fork(watcher);
         yield sagaEffects.fork(function *() {
           yield sagaEffects.take(`${model.namespace}/@@CANCEL_EFFECTS`);
@@ -24,7 +24,7 @@ export default function getSaga(resolve, reject, effects, model, onError, onEffe
   };
 }
 
-function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
+function getWatcher(key, _effect, model, onError, onEffect) {
   let effect = _effect;
   let type = 'takeEvery';
   let ms;
@@ -49,15 +49,16 @@ function getWatcher(resolve, reject, key, _effect, model, onError, onEffect) {
   }
 
   function *sagaWithCatch(...args) {
+    let {'@@resolve': resolve, '@@reject': reject} = args.length > 0 ? args[0] : {};
     try {
       yield sagaEffects.put({ type: `${key}${NAMESPACE_SEP}@@start` });
       const ret = yield effect(...args.concat(createEffects(model)));
       yield sagaEffects.put({ type: `${key}${NAMESPACE_SEP}@@end` });
-      resolve(key, ret);
+      resolve && resolve(ret);
     } catch (e) {
       onError(e);
       if (!e._dontReject) {
-        reject(key, e);
+        reject && reject(e);
       }
     }
   }

--- a/packages/dva-core/src/handleActions.js
+++ b/packages/dva-core/src/handleActions.js
@@ -6,10 +6,11 @@ function identify(value) {
 function handleAction(actionType, reducer = identify) {
   return (state, action) => {
     const { type } = action;
-    if (type && actionType !== type) {
-      return state;
+    invariant(type, 'dispatch: action should be a plain Object with type');
+    if (actionType === type) {
+      return reducer(state, action);
     }
-    return reducer(state, action);
+    return state;
   };
 }
 

--- a/packages/dva-core/src/index.js
+++ b/packages/dva-core/src/index.js
@@ -136,12 +136,8 @@ export function create(hooksAndOpts = {}, createOpts = {}) {
     };
 
     const sagaMiddleware = createSagaMiddleware();
-    const {
-      middleware: promiseMiddleware,
-      resolve,
-      reject,
-    } = createPromiseMiddleware(app);
-    app._getSaga = getSaga.bind(null, resolve, reject);
+    const promiseMiddleware = createPromiseMiddleware(app);
+    app._getSaga = getSaga;
 
     const sagas = [];
     const reducers = { ...initialReducer };

--- a/packages/dva-core/test/handleActions-test.js
+++ b/packages/dva-core/test/handleActions-test.js
@@ -44,4 +44,9 @@ describe('handleActions', () => {
     expect(reducers(initialState, { type: LOGIN_SAVE }))
       .toBe(initialState);
   });
+
+  it('dispatch not valid action', () => {
+    expect(reducers(initialState, { type: '' }))
+      .toThrow(/dispatch: action should be a plain Object with type/);
+  });
 });


### PR DESCRIPTION
当 dispatch action 为 {type: '', payload: {}} 时，会匹配所有的 reducers，进而会导致不可预知的异常，本次提交修复了这个问题 。关联issue #1403 