### PR TITLE
change container check logic by using official API

### DIFF
--- a/packages/dva/src/index.js
+++ b/packages/dva/src/index.js
@@ -53,7 +53,7 @@ export default function (opts = {}) {
 
     // 并且是 HTMLElement
     invariant(
-      !container || isHTMLElement(container),
+      isHTMLElement(container),
       `[app.start] container should be HTMLElement`,
     );
 
@@ -83,7 +83,7 @@ export default function (opts = {}) {
 }
 
 function isHTMLElement(node) {
-  return typeof node === 'object' && node !== null && node.nodeType && node.nodeName;
+  return node instanceof HTMLElement;
 }
 
 function isString(str) {


### PR DESCRIPTION
`!container || isHTMLElement(container),`这行代码的意思应该是container为假或者container是HTML元素。这个逻辑有问题。应该改成`container && isHTMLElement(container)`合适。
新改了一版isHTMLElement，可以兼容container为null或者undefined的情况，所以直接改成`isHTMLElement(container)`