### PR TITLE
Rewrite dynamic with async

### DIFF
--- a/packages/dva/package.json
+++ b/packages/dva/package.json
@@ -41,7 +41,6 @@
     "history": "^4.6.3",
     "invariant": "^2.2.2",
     "isomorphic-fetch": "^2.2.1",
-    "react-async-component": "^1.0.0-beta.3",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",
     "react-router-redux": "5.0.0-alpha.8",

--- a/packages/dva/src/dynamic.js
+++ b/packages/dva/src/dynamic.js
@@ -15,20 +15,19 @@ let defaultLoadingComponent = () => null;
 export default function dynamic(config) {
   const {
     resolve = defaultLoader,
+    app,
+    models: modelsLoader = () => [],
+    component: componentLoader,
   } = config;
 
+  // check config
+  invariant(
+    typeof componentLoader === 'function',
+    `config.component should be a function and return a Promise with Compoennt,
+     but it is ${typeof componentLoader}`,
+  );
+
   async function defaultLoader() {
-    const {
-      app,
-      models: modelsLoader = () => [],
-      component: componentLoader,
-    } = config;
-    // check config
-    invariant(
-      typeof componentLoader === 'function',
-      `config.component should be a function and return a Promise with Compoennt,
-       but it is ${typeof componentLoader}`,
-    );
     // load component & models
     const [
       actualComponent,

--- a/packages/dva/src/dynamic.js
+++ b/packages/dva/src/dynamic.js
@@ -38,7 +38,15 @@ export default function dynamic(config) {
       ...modelsLoader(),
     ]);
     // register models
-    actualModels.forEach(m => registerModel(app, m));
+    actualModels.forEach(
+      (m) => {
+        if (Array.isArray(m)) {
+          m.forEach(sub => registerModel(app, sub));
+        } else {
+          registerModel(app, m);
+        }
+      },
+    );
     // return component
     return actualComponent;
   }


### PR DESCRIPTION
重写了一下dynamic的默认resolve代码。
1. 减少了dynamic的层级，少了一层asyncComponent的函数调用。
2. 使用async/await，让代码看起来更直观一些。
3. 避免了多次解构config。
4. 去掉没用到的react-async-component依赖