### PR TITLE
feat: Support `put.sync` to wait the effect to resolve

### DIFF
--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -104,6 +104,22 @@ function createEffects(model) {
     assertAction(type, 'sagaEffects.put');
     return sagaEffects.put({ ...action, type: prefixType(type, model) });
   }
+
+  // The operator `put` doesn't block waiting the returned promise to resolve.
+  // Using `put.sync` will wait until the promsie resolve/reject before resuming.
+  // It will be helpful to organize multi-effects in order,
+  // and increase the reusability by seperate the effect in stand-alone pieces.
+  // https://github.com/redux-saga/redux-saga/issues/336
+  function putSync(action) {
+    const { type } = action;
+    assertAction(type, 'sagaEffects.put.sync');
+    return sagaEffects.put.sync({
+      ...action,
+      type: prefixType(type, model),
+    });
+  }
+  put.sync = putSync;
+
   function take(type) {
     if (typeof type === 'string') {
       assertAction(type, 'sagaEffects.take');


### PR DESCRIPTION
## Add ``put.sync`` effect

``put.sync`` is a native effect API of redux-saga. This PR will patch this behavior to the effect of dva.

> In order to wait for the returned Promise, use the variant put.sync(...) which will wait until the Promise resolve (or rejects) before resuming.

## Use cases

- Dispatch other effects in order

```
const model = {
  namespace: '@user',
  ...,
  effects: {
    *fetchList({ payload }, { call }) {
      const list = yield call(service.fetchList, payload)
      yield put({ type: 'dumpList', payload: list })
    },
    *delete({ payload }, { call }) {
      yield call(service.delete, payload)
    },
    *deleteAndReload({ payload }, { put }) {
      yield put.sync({ type: 'delete', payload })
      yield put({ type: 'fetchList' })
    }
  }
}
```