### PR TITLE
Feat(dva-immer): compatibility with normal reducer modify pattern

### DIFF
--- a/packages/dva-immer/README.md
+++ b/packages/dva-immer/README.md
@@ -26,6 +26,8 @@ some like [umi-plugin-dva](https://github.com/umijs/umi/blob/master/packages/umi
 
 Look more [Immer](https://github.com/mweststrate/immer)
 
+PS. :smile: dva-immer still support [normal reducer modify pattern](./test/index.test.js#L34), which is great for migration a old codebase.
+
 
 ## License
 

--- a/packages/dva-immer/src/index.js
+++ b/packages/dva-immer/src/index.js
@@ -5,13 +5,18 @@ export default function() {
     _handleActions(handlers, defaultState) {
       return (state = defaultState, action) => {
         const { type } = action;
+        let compatiableRet;
         const ret = produce(state, draft => {
           const handler = handlers[type];
           if (handler) {
-            handler(draft, action);
+            compatiableRet = handler(draft, action);
           }
         });
-        return ret === undefined ? {} : ret;
+        return compatiableRet !== undefined
+          ? compatiableRet
+          : ret === undefined
+            ? {}
+            : ret;
       };
     },
   };

--- a/packages/dva-immer/test/index.test.js
+++ b/packages/dva-immer/test/index.test.js
@@ -30,4 +30,42 @@ describe('dva-immer', () => {
     expect(oldCount.a.b.c).toEqual(0);
     expect(newCount.a.b.c).toEqual(1);
   });
+
+  it('compatibility with normal reducer usage', () => {
+    const app = dva();
+    app.use(userImmer());
+
+    app.model({
+      namespace: 'count',
+      state: {
+        a: {
+          b: {
+            c: 0,
+          },
+        },
+      },
+      reducers: {
+        add(state) {
+          return {
+            ...state,
+            a: {
+              ...state.a,
+              b: {
+                ...state.a.b,
+                c: state.a.b.c + 1,
+              },
+            },
+          };
+        },
+      },
+    });
+    app.router(() => 1);
+    app.start();
+
+    const oldCount = app._store.getState().count;
+    app._store.dispatch({ type: 'count/add' });
+    const newCount = app._store.getState().count;
+    expect(oldCount.a.b.c).toEqual(0);
+    expect(newCount.a.b.c).toEqual(1);
+  });
 });


### PR DESCRIPTION
cc/ @sorrycc 

这个兼容对旧项目是个福音，比如我们的业务，非常想用上 dva-immer, 但是全量旧代码的重构是很难做到的，做下兼容的话，旧项目就可以渐进的迁移了。