### PR TITLE
fix: unnecessary param of createReducer

### DIFF
--- a/packages/dva-core/src/index.js
+++ b/packages/dva-core/src/index.js
@@ -78,7 +78,7 @@ export function create(hooksAndOpts = {}, createOpts = {}) {
       m.state,
       plugin._handleActions
     );
-    store.replaceReducer(createReducer(store.asyncReducers));
+    store.replaceReducer(createReducer());
     if (m.effects) {
       store.runSaga(
         app._getSaga(m.effects, m, onError, plugin.get('onEffect'))


### PR DESCRIPTION
there's no need to pass asyncReducer from argument