### PR TITLE
fix: take(Array) don't work property

### DIFF
--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -129,7 +129,7 @@ function createEffects(model) {
         type.map(t => {
           if (typeof t === 'string') {
             assertAction(t, 'sagaEffects.take');
-            return prefixType(type, model);
+            return prefixType(t, model);
           }
           return t;
         })


### PR DESCRIPTION
when the first parameter of function take is typeof array, in the callback of type.map call, at line 132, the first parameter of prefixType, passing variable type (is array, not a take pattern) instead of t (array item, take pattern) causes incorrect result.
当take的第一个参数是数组时，在type.map调用的回调函数中，在132行，prefixType的第一个参数，传递变量type（是数组，而不是take模式）而不是t（是数组项，take模式）会导致错误结果。