### PR TITLE
feature: add selectState saga effect

### DIFF
--- a/docs/knowledgemap/README.md
+++ b/docs/knowledgemap/README.md
@@ -593,6 +593,12 @@ const result = yield call(fetch, '/todos');
 const todos = yield select(state => state.todos);
 ```
 
+也可以方便的取出当前model内的state
+
+```javascript
+const todos = yield select((state, modelName) => state[modelName]);
+```
+
 ### 错误处理
 
 #### 全局错误处理

--- a/docs/knowledgemap/README.md
+++ b/docs/knowledgemap/README.md
@@ -587,16 +587,18 @@ const result = yield call(fetch, '/todos');
 
 #### select
 
-用于从 state 里获取数据。
+用于从 store 里获取数据。
 
 ```javascript
-const todos = yield select(state => state.todos);
+const todos = yield select(store => store.todos);
 ```
 
-也可以方便的取出当前model内的state
+#### selectState
+
+取出当前model内的state
 
 ```javascript
-const todos = yield select((state, modelName) => state[modelName]);
+const todos = yield selectState((state) => state);
 ```
 
 ### 错误处理

--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -138,7 +138,15 @@ function createEffects(model) {
       return sagaEffects.take(type);
     }
   }
-  return { ...sagaEffects, put, take };
+
+  function select(func) {
+    function selectFunc(state) {
+      return func(state, model.namespace);
+    }
+    return sagaEffects.select(selectFunc);
+  }
+
+  return { ...sagaEffects, put, take, select };
 }
 
 function applyOnEffect(fns, effect, model, key) {

--- a/packages/dva-core/src/getSaga.js
+++ b/packages/dva-core/src/getSaga.js
@@ -139,14 +139,13 @@ function createEffects(model) {
     }
   }
 
-  function select(func) {
-    function selectFunc(state) {
-      return func(state, model.namespace);
-    }
-    return sagaEffects.select(selectFunc);
+  function selectState(selector, ...args) {
+    return sagaEffects.select(store =>
+      selector(store[model.namespace], ...args)
+    );
   }
 
-  return { ...sagaEffects, put, take, select };
+  return { ...sagaEffects, put, take, selectState };
 }
 
 function applyOnEffect(fns, effect, model, key) {

--- a/packages/dva-core/test/effects.test.js
+++ b/packages/dva-core/test/effects.test.js
@@ -164,6 +164,59 @@ describe('effects', () => {
     expect(takenCount).toEqual(2);
   });
 
+  it('selectState', done => {
+    const app = create();
+    app.model({
+      namespace: 'count',
+      state: 0,
+      reducers: {
+        add(state, { payload }) {
+          return state + payload || 1;
+        },
+      },
+      effects: {
+        *test(action, { put, selectState }) {
+          yield put({ type: 'add', payload: 2 });
+          const count = yield selectState(state => state);
+          expect(count).toEqual(2);
+          done();
+        },
+      },
+    });
+    app.start();
+    app._store.dispatch({ type: 'count/test' });
+  });
+
+  it('selectState with args', done => {
+    const app = create();
+    app.model({
+      namespace: 'count',
+      state: {
+        counter: 0,
+      },
+      reducers: {
+        add(state, { payload }) {
+          return {
+            counter: state.counter + payload || 1,
+          };
+        },
+      },
+      effects: {
+        *test(action, { put, selectState }) {
+          yield put({ type: 'add', payload: 1 });
+          const counter = yield selectState(
+            (state, name) => state[name],
+            'counter'
+          );
+          expect(counter).toEqual(1);
+          done();
+        },
+      },
+    });
+    app.start();
+    app._store.dispatch({ type: 'count/test' });
+  });
+
   it('dispatch action for other models', () => {
     const app = create();
     app.model({


### PR DESCRIPTION
原內容：

~~将model name带入select effect function中的第二个参数。
此功能可以方便搭配dva-model-extend使用~~

修正：

為了保持saga原本的select api，因此最後決定新增一個selectState的effect，其API跟select effect一致，不同點在於selector第一個參數傳入的值為當前model的state


以下为使用范例：

``` javascript
const todos1 = yield select((store) => store.todos);
const todos2 = yield selectState((state) => state);
expect(todos1).toEqual(todos2);
```

搭配dva-model-extend使用：
``` javascript
import modelExtend from 'dva-model-extend';

const human = {
  effects: {
    *talk({ payload }, { select }) {
      const name = yield selectState(state => state.name)
      console.log(`My name is ${name}`)
    }
  }
};

const benjy = modelExtend(human, {
  namespace: 'human.benjy',
  state: {
    name: 'Benjy',
  },
});
```