### PR TITLE
fix: lock react-redux to 5.0.7

### DIFF
--- a/packages/dva-no-router/package.json
+++ b/packages/dva-no-router/package.json
@@ -31,7 +31,7 @@
     "global": "^4.3.2",
     "invariant": "^2.2.2",
     "isomorphic-fetch": "^2.2.1",
-    "react-redux": "^5.0.5",
+    "react-redux": "5.0.7",
     "redux": "^3.7.2"
   },
   "peerDependencies": {

--- a/packages/dva-react-router-3/package.json
+++ b/packages/dva-react-router-3/package.json
@@ -31,7 +31,7 @@
     "global": "^4.3.2",
     "invariant": "^2.2.2",
     "isomorphic-fetch": "^2.2.1",
-    "react-redux": "^5.0.5",
+    "react-redux": "5.0.7",
     "react-router": "^3.0.5",
     "react-router-redux": "^4.0.8",
     "redux": "^3.7.2"

--- a/packages/dva/package.json
+++ b/packages/dva/package.json
@@ -35,7 +35,7 @@
     "history": "^4.6.3",
     "invariant": "^2.2.2",
     "isomorphic-fetch": "^2.2.1",
-    "react-redux": "^5.0.5",
+    "react-redux": "5.0.7",
     "react-router-dom": "^4.1.2",
     "react-router-redux": "5.0.0-alpha.9",
     "redux": "^3.7.2"


### PR DESCRIPTION
## 问题

![ladpdgq9qtrb8qvnavrnchi_2162_346 jpg_620x10000q90g](https://user-images.githubusercontent.com/35128/47548346-5eacbc80-d92b-11e8-9c0e-8010bec7ad32.jpg)

## 解决

锁定 react-redux 版本。
