### PR TITLE
修复model卸载后无法重新挂载bug(dynamic)

### DIFF
--- a/packages/dva/src/dynamic.js
+++ b/packages/dva/src/dynamic.js
@@ -1,11 +1,14 @@
 import React, { Component } from 'react';
 
-const cached = {};
 function registerModel(app, model) {
   model = model.default || model;
-  if (!cached[model.namespace]) {
+
+  if (
+    !app._models.some(item => {
+      return item.namespace === model.namespace;
+    })
+  ) {
     app.model(model);
-    cached[model.namespace] = 1;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->
- 修改注册model条件
``dynamic.js``
```js
var cached = {};

function registerModel(app, model) {
  model = model.default || model;

  if (!cached[model.namespace]) {
    app.model(model);
    cached[model.namespace] = 1;
  }
}
```
当执行``app.unmodel``卸载model时，并没有修改``cached``缓存，所以重复挂在model时，永远不会执行``app.model``, 应该从``app._models``中判断
```js
function registerModel(app, model) {
  model = model.default || model;
  if (
    !app._models.some(item => {
      return item.namespace === model.namespace;
    })
  ) {
    app.model(model);
  }
}

```
- close https://github.com/dvajs/dva/issues/1482