### PR TITLE
feat: open redux-devtool trace history

### DIFF
--- a/packages/dva-core/src/createStore.js
+++ b/packages/dva-core/src/createStore.js
@@ -29,7 +29,7 @@ export default function({
   const composeEnhancers =
   process.env.NODE_ENV !== "production" &&
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ trace: true,maxAge:30 })
     : compose;
 
   const enhancers = [applyMiddleware(...middlewares), ...extraEnhancers];

--- a/packages/dva-core/src/createStore.js
+++ b/packages/dva-core/src/createStore.js
@@ -16,7 +16,7 @@ export default function({
   const extraEnhancers = plugin.get('extraEnhancers');
   invariant(
     isArray(extraEnhancers),
-    `[app.start] extraEnhancers should be array, but got ${typeof extraEnhancers}`
+    `[app.start] extraEnhancers should be array, but got ${typeof extraEnhancers}`,
   );
 
   const extraMiddlewares = plugin.get('onAction');
@@ -27,10 +27,10 @@ export default function({
   ]);
 
   const composeEnhancers =
-  process.env.NODE_ENV !== "production" &&
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ trace: true,maxAge:30 })
-    : compose;
+    process.env.NODE_ENV !== 'production' &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+      ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ trace: true, maxAge: 30 })
+      : compose;
 
   const enhancers = [applyMiddleware(...middlewares), ...extraEnhancers];
 


### PR DESCRIPTION
## 增加`Redux`调试面板`trace`调用记录

- 打开 `Redux`面板`trace`的开关,保留默认`10`条记录

Checklist

- [x] npm test passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

Description of change

`dva-core/src/createStore.js`

**before**

```javascript
const composeEnhancers =
  process.env.NODE_ENV !== "production" &&
  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
    : compose;

const enhancers = [applyMiddleware(...middlewares), ...extraEnhancers];
```

**after**

```javascript
  const composeEnhancers =
  process.env.NODE_ENV !== "production" &&
  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ trace: true,maxAge:30 })
    : compose;

  const enhancers = [applyMiddleware(...middlewares), ...extraEnhancers];
```

首先`dva`非常好用

但是在现在开发的项目中`model`定义超过**100**个,由不同的开发人员进行开发，在调度`model`上各不同，调试变得略微麻烦，在找寻解决方法时发现`redux`有提供*调用追踪*，并在项目中使用，对于项目中追踪调度和调试还有有效率上的改变，所以希望能在`dva`这么一个优秀的开源项目中提供一`PR`，享受更便捷的调试