### PR TITLE
deps: use typings exported from `@types/react-redux`

### DIFF
--- a/packages/dva/index.d.ts
+++ b/packages/dva/index.d.ts
@@ -121,15 +121,10 @@ export interface DvaInstance {
 
 export default function dva(opts?: DvaOption): DvaInstance;
 
-/**
- * Connects a React component to Dva.
- */
-export function connect(
-  mapStateToProps?: Function,
-  mapDispatchToProps?: Function,
-  mergeProps?: Function,
-  options?: Object
-): Function;
+export {
+  connect, connectAdvanced, useSelector, useDispatch, useStore,
+  DispatchProp,
+} from 'react-redux';
 
 import * as routerRedux from 'connected-react-router';
 export { routerRedux };

--- a/packages/dva/package.json
+++ b/packages/dva/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@types/isomorphic-fetch": "^0.0.35",
+    "@types/react-redux": "^7.1.0",
     "@types/react-router-dom": "^4.3.1",
     "connected-react-router": "^6.3.2",
     "dva-core": "1.6.0-beta.5",


### PR DESCRIPTION
https://github.com/dvajs/dva/issues/2133

补充了  `d.ts` 里的 `useSelector` 等 API.
`interface` 类的目前只 export 了 `DispatchProp`，这个比较常用。`@types/react-redux` 暴露的 `interfaces` 太多，就没有一一处理。