### PR TITLE
fix: qiankun remount dva model

### DIFF
--- a/packages/dva-core/src/prefixNamespace.js
+++ b/packages/dva-core/src/prefixNamespace.js
@@ -19,7 +19,8 @@ export default function prefixNamespace(model) {
 
   if (reducers) {
     if (isArray(reducers)) {
-      model.reducers[0] = prefix(reducers[0], namespace, 'reducer');
+      const [reducer, ...rest] = reducers;
+      model.reducers = [prefix(reducer, namespace, 'reducer'), ...rest];
     } else {
       model.reducers = prefix(reducers, namespace, 'reducer');
     }

--- a/packages/dva-core/src/prefixNamespace.js
+++ b/packages/dva-core/src/prefixNamespace.js
@@ -19,6 +19,7 @@ export default function prefixNamespace(model) {
 
   if (reducers) {
     if (isArray(reducers)) {
+      // 需要复制一份，不能直接修改 model.reducers[0], 会导致微前端场景下，重复添加前缀
       const [reducer, ...rest] = reducers;
       model.reducers = [prefix(reducer, namespace, 'reducer'), ...rest];
     } else {


### PR DESCRIPTION
fix: qiankun remount for array type reducers

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

Using the mutate array method to prefix namespace will cause reducers' prefix keep growing on each remount in micro-frontend env.

![image](https://user-images.githubusercontent.com/19804057/102160688-e154b500-3ec0-11eb-8a53-9c1c2a434cfd.png)

