### PR TITLE
feat: lock the version of history

### DIFF
--- a/packages/dva/package.json
+++ b/packages/dva/package.json
@@ -37,7 +37,7 @@
     "connected-react-router": "6.5.2",
     "dva-core": "2.0.4",
     "global": "^4.3.2",
-    "history": "^4.7.2",
+    "history": "~4.7.2",
     "invariant": "^2.2.4",
     "isomorphic-fetch": "^2.2.1",
     "react-redux": "^7.1.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/dvajs/dva/ISSUE_URL


#### Background
- 当前 dva `dependencies`中使用的 history 版本是 `^4.7.2`。 **` ^`** 的语意化是指保持第一个非零版本一致, 这会导致项目中安装的 `history` 永远是 4.x 中的最新版本
- 但是 `history` 并不想我们想的那样严格遵守语意化

比如 4.7.x 中 babel/core 的版本是 6.x

https://github.com/ReactTraining/history/blob/v4.7.1/package.json#L40-L43

<img src="https://user-images.githubusercontent.com/26377119/112748955-dc3fef80-8ff1-11eb-8597-7b30db5f26b7.png" height="280"></img>

但是在 4.9 中

https://github.com/ReactTraining/history/blob/6104a6a2e40ae17a47a297621afff9a6cb184bfc/package.json#L34-L47

<img src="https://user-images.githubusercontent.com/26377119/112749601-eb28a100-8ff5-11eb-9356-c9732fd8d099.png" height="280"></img>



#### reproduction
[最小复现由于 history 中 babel 版本导致的问题](https://github.com/wang123screet/dva-demo-error)


#### error msg
![image](https://user-images.githubusercontent.com/26377119/112749102-bb2bce80-8ff2-11eb-8638-7853d37d4cba.png)






