### PR TITLE
chore: update dva-immer peerDependencies to avoid conflict.

### DIFF
--- a/packages/dva-immer/package.json
+++ b/packages/dva-immer/package.json
@@ -10,7 +10,7 @@
     "immer": "^8.0.4"
   },
   "peerDependencies": {
-    "dva": "^2.5.0-0"
+    "dva": "^2.6.0-beta.22"
   },
   "devDependencies": {
     "dva": "2.6.0-beta.22"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

There is a conflict of dva version when using umi & umi/plugin-dva  from the latest version: 


> npm WARN ERESOLVE overriding peer dependency
> npm WARN Found: dva@2.6.0-beta.22
> npm WARN node_modules/@umijs/plugin-dva/node_modules/dva
> npm WARN   dva@"^2.6.0-beta.20" from @umijs/plugin-dva@0.12.1
> npm WARN   node_modules/@umijs/plugin-dva
> npm WARN     @umijs/plugin-dva@"0.12.1" from @umijs/preset-react@1.8.7
> npm WARN     node_modules/@umijs/preset-react
> npm WARN
> npm WARN Could not resolve dependency:
> npm WARN peer dva@"^2.5.0-0" from dva-immer@0.5.2
> npm WARN node_modules/@umijs/plugin-dva/node_modules/dva-immer
> npm WARN   dva-immer@"^0.5.2" from @umijs/plugin-dva@0.12.1
> npm WARN   node_modules/@umijs/plugin-dva

