### PR TITLE
fix(dva): typing of param in interface 'Router'

### DIFF
--- a/packages/dva/index.d.ts
+++ b/packages/dva/index.d.ts
@@ -81,7 +81,7 @@ export interface RouterAPI {
 }
 
 export interface Router {
-  (api?: RouterAPI): JSX.Element | Object,
+  (api: RouterAPI): JSX.Element | Object,
 }
 
 export interface DvaInstance {


### PR DESCRIPTION
The param `api` is non-null, according to the source code: https://github.com/dvajs/dva/blob/3eaee309ede9cf1e255326150ee2210bd04c1abf/packages/dva/src/index.js#L96

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/dvajs/dva/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- Fixes the typing of `Router`. Its param `api` is non-null, according to the source code (however, written in JavaScript).
