### PR TITLE
chore(checkModel): 异常提示出是哪一个namespace重复了

### DIFF
--- a/packages/dva-core/src/checkModel.js
+++ b/packages/dva-core/src/checkModel.js
@@ -14,7 +14,7 @@ export default function checkModel(model, existModels) {
   // 并且唯一
   invariant(
     !existModels.some(model => model.namespace === namespace),
-    `[app.model] namespace should be unique`,
+    `[app.model] namespace should be unique : [${namespace}]`,
   );
 
   // state 可以为任意值


### PR DESCRIPTION
如果不小心有重名的namespace, 是会抛出异常，但是没有提示出哪一个namespace重复
