### PR TITLE
docs: remove dvajs.com references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ Lightweight front-end framework based on [redux](https://github.com/reactjs/redu
 
 ## Quick Start
 
-* [Real project with dva](https://dvajs.com/guide/getting-started.html)
-* [dva intro course](https://dvajs.com/guide/introduce-class.html)
-
-More documentation, checkout [https://dvajs.com/](https://dvajs.com/)
+See the [docs directory](./docs) for guides and API references.
 
 ## FAQ
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -23,11 +23,7 @@
 * **支持 HMR**，基于 [babel-plugin-dva-hmr](https://github.com/dvajs/babel-plugin-dva-hmr) 实现 components、routes 和 models 的 HMR
 
 ## 快速上手
-
-* [dva 和 antd 项目快速上手](https://dvajs.com/guide/getting-started.html)
-* [dva 入门课](https://dvajs.com/guide/introduce-class.html)
-
-更多文档，详见：[https://dvajs.com/](https://dvajs.com/)
+请参考 [docs 目录](./docs) 获取指南和 API 参考。
 
 ## 他是怎么来的？
 
@@ -67,9 +63,9 @@
 
 以下能帮你更好地理解和使用 dva ：
 
-* 理解 dva 的 [8 个概念](https://dvajs.com/guide/concepts.html) ，以及他们是如何串起来的
-* 掌握 dva 的[所有 API](https://dvajs.com/api/)
-* 查看 [dva 知识地图](https://dvajs.com/knowledgemap/) ，包含 ES6, React, dva 等所有基础知识
+* 理解 dva 的 [8 个概念](./docs/Concepts.md) ，以及他们是如何串起来的
+* 掌握 dva 的[所有 API](./docs/API.md)
+* 查看 [dva 知识地图](./docs/knowledgemap/README.md) ，包含 ES6, React, dva 等所有基础知识
 * 查看 [更多 FAQ](https://github.com/dvajs/dva/issues?q=is%3Aissue+is%3Aclosed+label%3Afaq)，看看别人通常会遇到什么问题
 * 如果你基于 dva-cli 创建项目，最好了解他的 [配置方式](https://github.com/sorrycc/roadhog/blob/master/README_zh-cn.md#配置)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,5 @@
 # API
 
-[以中文版查看此文](https://dvajs.com/api/)
-
 ## Export Files
 ### dva
 

--- a/docs/Concepts.md
+++ b/docs/Concepts.md
@@ -1,7 +1,5 @@
 # Concepts
 
-[以中文版查看此文](https://dvajs.com/guide/concepts.html)
-
 ## Data Flow
 
 <img src="https://zos.alipayobjects.com/rmsportal/PPrerEAKbIoDZYr.png" width="807" />

--- a/website/now.json
+++ b/website/now.json
@@ -1,10 +1,7 @@
 {
-  "name": "dvajs.com",
+  "name": "dva",
   "version": 2,
   "builds": [
     { "src": "package.json", "use": "@now/static-build" }
-  ],
-  "alias": [
-    "dvajs.com"
   ]
 }


### PR DESCRIPTION
## Summary
- remove references to deprecated dvajs.com site from docs
- point users to local docs directory
- strip old domain from website config

## Testing
- `npm test` *(fails: Cannot find module 'redux' from 'index.js')*
- `npm install redux mm --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mm)*

------
https://chatgpt.com/codex/tasks/task_e_6892d7ff98488324b5e3101d23e20981